### PR TITLE
44 fix openalexconcept and keyterms pipeline

### DIFF
--- a/cag/framework/annotator/instance/keyterms_orchestrator.py
+++ b/cag/framework/annotator/instance/keyterms_orchestrator.py
@@ -38,6 +38,7 @@ class KeyTermsPipeOrchestrator(PipeOrchestrator):
 
                     record = {f"metodeo_keyterm_{x}": y for x, y in entry.items()}
                     record["metodeo_keyterm"] = term
+                    record['text_key'] = text_key
                     out_arr.append(record)
             out_df: pd.DataFrame = pd.DataFrame(out_arr)
 

--- a/cag/framework/annotator/instance/openalex_concept_orchestrator.py
+++ b/cag/framework/annotator/instance/openalex_concept_orchestrator.py
@@ -22,27 +22,27 @@ class OAConceptPipeOrchestrator(PipeOrchestrator):
             text_key = context["_key"]
 
             for level, oa_concepts in doc._.oa_concepts.items():
-                
-                oaconcept_node: Document = self.create_node(oa_concepts[0],
-                                                            oa_concepts[1])
-                text_node: Document = self.get_document(
-                    self.annotated_node, {"_key": text_key}
-                )
+                for oa_concept_name, oa_concept_id in oa_concepts:
+                    oaconcept_node: Document = self.create_node(oa_concept_id,
+                                                                oa_concept_name)
+                    text_node: Document = self.get_document(
+                        self.annotated_node, {"_key": text_key}
+                    )
 
-                entry = {
-                    "level": level,
-                    "metadata": OpenAlexConcept.__METADATA__
-                }
+                    entry = {
+                        "level": level,
+                        "metadata": OpenAlexConcept.__METADATA__
+                    }
 
-                _: Document = self.create_edge(
-                    text_node, oaconcept_node, entry
-                )
+                    _: Document = self.create_edge(
+                        text_node, oaconcept_node, entry
+                    )
 
-                record = {f"oaconcept_{x}": y for x, y in entry.items()}
-                record["oaconcept_id"] = oa_concepts[0]
-                record["oaconcept_name"] = oa_concepts[1]
-                record["text_key"] = text_key
-                out_arr.append(record)
+                    record = {f"oaconcept_{x}": y for x, y in entry.items()}
+                    record["oaconcept_id"] = oa_concept_id
+                    record["oaconcept_name"] = oa_concept_name
+                    record["text_key"] = text_key
+                    out_arr.append(record)
         out_df: pd.DataFrame = pd.DataFrame(out_arr)
 
         return out_df

--- a/cag/framework/annotator/pipe/linguistic/oaconcept.py
+++ b/cag/framework/annotator/pipe/linguistic/oaconcept.py
@@ -8,13 +8,17 @@ from transformers.utils import logging
 
 import requests
 import json
-from dotenv import load_dotenv
+from dotenv import load_dotenv, find_dotenv
 
 import os
 
 
 def get_oaconcepts(text_string, text_lng="en"):
-    load_dotenv()
+    load_success = load_dotenv()
+    if not load_success:
+        # try loading '.env' file from current working dir
+        load_dotenv(find_dotenv(usecwd=True))
+
     taxo_parms_dict = {
         "enScience": {
             "taxonomy": "OpenAlex",


### PR DESCRIPTION
Three changes happened in this branch:

1. Enabling local .env files for the OAConcept pipe

2. Adding "text_key" column in Keyterms dataframe to avoid merge error in pipeline_base's `save()`

3. Adapting OpenAlex Concept Orchestrator to new output format